### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,5 @@ KERNEL_MODULE_OBJECT_FILE_LIST := irqsync.o kgdboe_main.o kgdboe_io.o nethook.o 
 
 obj-m := $(KERNEL_MODULE_NAME).o
 $(KERNEL_MODULE_NAME)-y += $(KERNEL_MODULE_OBJECT_FILE_LIST)
-ccflags-y := -ggdb -Og -std=gnu99
+ccflags-y := -ggdb -O0 -std=gnu99 -D_FORTIFY_SOURCE=0
 


### PR DESCRIPTION
Fixed gcc-12.2.1 & kernel 5.19.8 compile error

make -C /lib/modules/5.19.8-200.fc36.x86_64/build M=/devel/kgdboe modules make[1]: Entering directory '/usr/src/kernels/5.19.8-200.fc36.x86_64'
  CC [M]  /devel/kgdboe/irqsync.o
In file included from ./include/linux/string.h:253,
                 from ./include/linux/bitmap.h:11,
                 from ./include/linux/cpumask.h:12,
                 from ./arch/x86/include/asm/cpumask.h:5,
                 from ./arch/x86/include/asm/msr.h:11,
                 from ./arch/x86/include/asm/processor.h:22,
                 from ./arch/x86/include/asm/cpufeature.h:5,
                 from ./arch/x86/include/asm/thread_info.h:53,
                 from ./include/linux/thread_info.h:60,
                 from ./arch/x86/include/asm/preempt.h:7,
                 from ./include/linux/preempt.h:78,
                 from ./include/linux/spinlock.h:55,
                 from ./include/linux/irq.h:14,
                 from /devel/kgdboe/irqsync.h:2,
                 from /devel/kgdboe/irqsync.c:1:
In function ‘fortify_memset_chk’,
    inlined from ‘irqsync_create’ at /devel/kgdboe/irqsync.c:27:2:
./include/linux/fortify-string.h:254:25: error: call to ‘__write_overflow’ declared with attribute error: detected write beyond size of object (1st parameter)
  254 |                         __write_overflow();
      |                         ^~~~~~~~~~~~~~~~~~
make[2]: *** [scripts/Makefile.build:249: /devel/kgdboe/irqsync.o] Error 1
make[1]: *** [Makefile:1851: /devel/kgdboe] Error 2
make[1]: Leaving directory '/usr/src/kernels/5.19.8-200.fc36.x86_64'
make: *** [Makefile:16: all] Error 2