### PR TITLE
Add errors on unsupported CONFIG_KGDB_KDB config

### DIFF
--- a/kgdboe_main.c
+++ b/kgdboe_main.c
@@ -45,6 +45,10 @@ MODULE_LICENSE("GPL");
 #error Your kernel is built without support for KGDB (kernel debugger). Please rebuild your kernel with CONFIG_KGDB enabled.
 #endif
 
+#ifdef CONFIG_KGDB_KDB
+#error Your kernel is built with support for KDB frontend for KGDB. Kgdboe does not support it. Please rebuild your kernel with CONFIG_KGDB_KDB disabled.
+#endif
+
 static int udp_port = 31337;
 module_param(udp_port, int, 0444);
 

--- a/nethook.c
+++ b/nethook.c
@@ -39,6 +39,10 @@
 #error kgdboe requires kgdb support. Please enable CONFIG_KGDB in your KConfig and rebuild the kernel
 #endif
 
+#if defined(CONFIG_KGDB_KDB) || CONFIG_KGDB_KDB
+#error kgdboe does not support kdb. Please disable CONFIG_KGDB_KDB in your KConfig and rebuild the kernel
+#endif
+
 #if !defined(CONFIG_TRACEPOINTS) || !CONFIG_TRACEPOINTS
 #error kgdboe requires tracepoint support. Please enable CONFIG_FTRACE and CONFIG_TRACEPOINTS in your KConfig and rebuild the kernel
 #endif


### PR DESCRIPTION
As suggested in #15, it seems that KGDB_KDB does not work with kgdboe, so I think we should error out on it.