### PR TITLE
Add Support for Linux 6.9.0+

### DIFF
--- a/kgdboe_main.c
+++ b/kgdboe_main.c
@@ -38,6 +38,7 @@
 #include "kgdboe_io.h"
 
 MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("KGDBoE - A Network Based KGDB Extension");
 
 #include <linux/timer.h>
 

--- a/nethook.c
+++ b/nethook.c
@@ -202,7 +202,11 @@ bool nethook_initialize(struct net_device *dev)
 
 	nethook.hooked_device = dev;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6,9,0)
 	for (i = 0; i < nr_irqs; i++)
+#else
+	for (i = 0; i < irq_get_nr_irqs(); i++)
+#endif
 	{
 		struct irq_desc *desc = pirq_to_desc(i);
 		if (!desc || !desc->action)


### PR DESCRIPTION
Added Fix for Several Linux 6.9.0 issues:
- del_timer is deprecated, use delete_timer_sync
- timer_of renamed to timer_container_of
- Linux net global variables were consolidated to net_hotdata, gro_normal_batch is now part of the net_hotdata struct
- nr_irq is not longer an accessible global, used irq_get_nr_irq()

This pull request does not address any **existing** warning.